### PR TITLE
fix: removed bonn-cropbio 75M; missing token

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -73,23 +73,6 @@ variant-calls:
       restricted-access-token-envvar: BO_AGILENT_TOKEN
       filename: cropbioBonn_WGGC_WES_CN_200M.vcf.gz
     benchmark: giab-NA12878-agilent-200M
-  BO-agilent-75M:
-    labels:
-      site: bonn-cropbio
-      pipeline: WES_WGGC_AG_Schoof
-      trimming: cutadapt
-      read-mapping: bwa-mem;novoalign
-      base-quality-recalibration: gatk
-      realignment: varlociraptor
-      variant-detection: haplotypecaller;bcftools mpileup;deepvariant;freebayes;delly
-      genotyping: varlociraptor
-      reads: 75M
-    subcategory: NA12878-agilent
-    zenodo:
-      deposition: 6472488
-      restricted-access-token-envvar: BO_AGILENT_TOKEN
-      filename: cropbioBonn_WGGC_WES_CN_75M.vcf.gz
-    benchmark: giab-NA12878-agilent-75M
   CO-agilent-200M:
     labels:
       site: cologne


### PR DESCRIPTION
- committed directly by mistake: https://github.com/koesterlab/benchmarking-ngscn-sig4/commit/744c4a473a793af8fb92cb40bcaaae956f03a00c
- included bonn-cropbio 75M agilent results for which token does not work 
- fix removes 75M results entries for bonn-cropbio